### PR TITLE
fix rent burn percentage

### DIFF
--- a/genesis.sh
+++ b/genesis.sh
@@ -21,7 +21,7 @@ args=(
   --bootstrap-stake-pubkey bootstrap-leader-stake-account.json
   --bootstrap-leader-lamports             1000000000 # 1 SOL for voting
   --bootstrap-leader-stake-lamports 1000000000000000 # 1 million SOL
-  --rent-burn-percentage 255                         # Burn it all!
+  --rent-burn-percentage 100                         # Burn it all!
   --target-lamports-per-signature 0                  # No transaction fees
   --ledger ledger
 )


### PR DESCRIPTION
#### Problem
As side effect of [#7217](https://github.com/solana-labs/solana/pull/7217) maximum value that could be specified for `rent-burn-percentage` argument is 100. Currently we are using 255 which will fail the validation.

#### Summary of Changes
Set value of `rent-burn-percentage` to 100.