### PR TITLE
Rename bootstrap-leader to bootstrap-validator

### DIFF
--- a/genesis.sh
+++ b/genesis.sh
@@ -30,12 +30,12 @@ default_arg() {
 }
 
 args=(
-  --bootstrap-leader-pubkey bootstrap-leader-identity.json
-  --bootstrap-vote-pubkey bootstrap-leader-vote-account.json
-  --bootstrap-stake-pubkey bootstrap-leader-stake-account.json
+  --bootstrap-validator-pubkey bootstrap-validator-identity.json
+  --bootstrap-vote-pubkey bootstrap-validator-vote-account.json
+  --bootstrap-stake-pubkey bootstrap-validator-stake-account.json
   --bootstrap-stake-authorized-pubkey 3b7akieYUyCgz3Cwt5sTSErMWjg8NEygD6mbGjhGkduB # "one thanks" catch-all community pool
-  --bootstrap-leader-lamports             1000000000 # 1 SOL for voting
-  --bootstrap-leader-stake-lamports  500000000000000 # 500,000 thousand SOL
+  --bootstrap-validator-lamports             1000000000 # 1 SOL for voting
+  --bootstrap-validator-stake-lamports  500000000000000 # 500,000 thousand SOL
   --rent-burn-percentage 100                         # Burn it all!
   --target-lamports-per-signature 0                  # No transaction fees
   --ledger ledger

--- a/keygen.sh
+++ b/keygen.sh
@@ -7,12 +7,12 @@ keygen() {
 
   solana-keygen --version
 
-  test -f bootstrap-leader-identity.json ||
-    (set -x; solana-keygen $cmd --outfile bootstrap-leader-identity.json)
-  test -f bootstrap-leader-vote-account.json ||
-    (set -x; solana-keygen $cmd --outfile bootstrap-leader-vote-account.json)
-  test -f bootstrap-leader-stake-account.json ||
-    (set -x; solana-keygen $cmd --outfile bootstrap-leader-stake-account.json)
+  test -f bootstrap-validator-identity.json ||
+    (set -x; solana-keygen $cmd --outfile bootstrap-validator-identity.json)
+  test -f bootstrap-validator-vote-account.json ||
+    (set -x; solana-keygen $cmd --outfile bootstrap-validator-vote-account.json)
+  test -f bootstrap-validator-stake-account.json ||
+    (set -x; solana-keygen $cmd --outfile bootstrap-validator-stake-account.json)
 }
 
 case "$1" in

--- a/launch-cluster.sh
+++ b/launch-cluster.sh
@@ -43,14 +43,14 @@ while [[ -n $1 ]]; do
 done
 
 ENTRYPOINT_INSTANCE=${INSTANCE_PREFIX}cluster-entrypoint
-BOOTSTRAP_LEADER_INSTANCE=${INSTANCE_PREFIX}cluster-bootstrap-leader
+BOOTSTRAP_VALIDATOR_INSTANCE=${INSTANCE_PREFIX}cluster-bootstrap-validator
 API_INSTANCE=${INSTANCE_PREFIX}cluster-api
 WAREHOUSE_INSTANCE=${INSTANCE_PREFIX}cluster-warehouse
 WATCHTOWER_INSTANCE=${INSTANCE_PREFIX}cluster-watchtower
 
 INSTANCES="
   $ENTRYPOINT_INSTANCE
-  $BOOTSTRAP_LEADER_INSTANCE
+  $BOOTSTRAP_VALIDATOR_INSTANCE
   $API_INSTANCE
   $WAREHOUSE_INSTANCE
   $WATCHTOWER_INSTANCE
@@ -166,12 +166,12 @@ echo ==========================================================
 )
 
 echo ==========================================================
-echo "Creating $BOOTSTRAP_LEADER_INSTANCE"
+echo "Creating $BOOTSTRAP_VALIDATOR_INSTANCE"
 echo ==========================================================
 (
   set -x
   gcloud --project "$PROJECT" compute instances create \
-    "$BOOTSTRAP_LEADER_INSTANCE" \
+    "$BOOTSTRAP_VALIDATOR_INSTANCE" \
     --zone "$ZONE" \
     --machine-type n1-standard-8 \
     --boot-disk-size=2TB \
@@ -243,18 +243,18 @@ echo ==========================================================
 )
 
 echo ==========================================================
-echo "Transferring files to $BOOTSTRAP_LEADER_INSTANCE"
+echo "Transferring files to $BOOTSTRAP_VALIDATOR_INSTANCE"
 echo ==========================================================
 (
   set -x
   gcloud --project "$PROJECT" compute scp --zone "$ZONE" --recurse \
-    bootstrap-leader-identity.json \
-    bootstrap-leader-stake-account.json \
-    bootstrap-leader-vote-account.json \
-    bootstrap-leader.service \
+    bootstrap-validator-identity.json \
+    bootstrap-validator-stake-account.json \
+    bootstrap-validator-vote-account.json \
+    bootstrap-validator.service \
     ledger \
     scripts/* \
-    "$BOOTSTRAP_LEADER_INSTANCE":
+    "$BOOTSTRAP_VALIDATOR_INSTANCE":
 )
 
 echo ==========================================================
@@ -318,7 +318,7 @@ for instance in $INSTANCES; do
     $ENTRYPOINT_INSTANCE)
       nodeType=entrypoint
       ;;
-    $BOOTSTRAP_LEADER_INSTANCE)
+    $BOOTSTRAP_VALIDATOR_INSTANCE)
       nodeType=bootstrap
       ;;
     *)


### PR DESCRIPTION
Bootstrap-leader has been renamed bootstrap-validator across the solana repo, including the genesis args.  Cluster launch repo should follow suit.