### PR TITLE
Add Access-Control-Allow-Origin * on 429 responses

### DIFF
--- a/bin/machine-setup.sh
+++ b/bin/machine-setup.sh
@@ -196,6 +196,7 @@ sudo bash -c "cat server.key server.crt >> /etc/ssl/private/haproxy.pem"
 rm ca.key ca.crt ca.srl server.crt server.csr server.key
 
 sudo add-apt-repository --yes ppa:certbot/certbot -r
+sudo add-apt-repository --yes ppa:vbernat/haproxy-2.2
 sudo apt-get --assume-yes install haproxy certbot
 
 # Our certs have a 2048bit DH param, haproxy's default is 1024. Bump it
@@ -218,7 +219,7 @@ frontend http
     stick-table  type ip  size 100k  expire 30s  store http_req_rate(1s)
     http-request track-sc0 src
     acl too_many_requests sc_http_req_rate(0) gt 300
-    http-request set-header Access-Control-Allow-Origin "*" if too_many_requests
+    http-request deny deny_status 429 hdr Access-Control-Allow-Origin "*" hdr Access-Control-Max-Age 86400  hdr Access-Control-Allow-Methods "POST, GET, OPTIONS" if too_many_requests METH_OPTIONS
     http-request deny deny_status 429 if too_many_requests
 
     # increase websocket idle timeout
@@ -251,7 +252,7 @@ frontend https
     stick-table  type ip  size 100k  expire 30s  store http_req_rate(1s)
     http-request track-sc0 src
     acl too_many_requests sc_http_req_rate(0) gt 300
-    http-request set-header Access-Control-Allow-Origin "*" if too_many_requests
+    http-request deny deny_status 429 hdr Access-Control-Allow-Origin "*" hdr Access-Control-Max-Age 86400  hdr Access-Control-Allow-Methods "POST, GET, OPTIONS" if too_many_requests METH_OPTIONS
     http-request deny deny_status 429 if too_many_requests
 
     # increase websocket idle timeout

--- a/bin/machine-setup.sh
+++ b/bin/machine-setup.sh
@@ -214,10 +214,12 @@ frontend http
     capture request header X-Forwarded-For len 15
     log-format "%ci:%cp [%tr] %ft %b/%s %TR/%Tw/%Tc/%Tr/%Ta %ST %B %CC %CS %tsc %ac/%fc/%bc/%sc/%rc %sq/%bq %{+Q}r %[capture.req.hdr(1)] %[capture.req.hdr(0)]"
 
-    # rate limit to 300 RPC requests in 2 seconds per IP
+    # rate limit to 300 RPC requests in 1 second per IP
     stick-table  type ip  size 100k  expire 30s  store http_req_rate(1s)
     http-request track-sc0 src
-    http-request deny deny_status 429 if { sc_http_req_rate(0) gt 300 }
+    acl too_many_requests sc_http_req_rate(0) gt 300
+    http-request set-header Access-Control-Allow-Origin "*" if too_many_requests
+    http-request deny deny_status 429 if too_many_requests
 
     # increase websocket idle timeout
     timeout client 30s
@@ -245,10 +247,12 @@ frontend https
     capture request header X-Forwarded-For len 15
     log-format "%ci:%cp [%tr] %ft %b/%s %TR/%Tw/%Tc/%Tr/%Ta %ST %B %CC %CS %tsc %ac/%fc/%bc/%sc/%rc %sq/%bq %{+Q}r %[capture.req.hdr(1)] %[capture.req.hdr(0)]"
 
-    # rate limit to 300 RPC requests in 2 seconds per IP
+    # rate limit to 300 RPC requests in 1 second per IP
     stick-table  type ip  size 100k  expire 30s  store http_req_rate(1s)
     http-request track-sc0 src
-    http-request deny deny_status 429 if { sc_http_req_rate(0) gt 300 }
+    acl too_many_requests sc_http_req_rate(0) gt 300
+    http-request set-header Access-Control-Allow-Origin "*" if too_many_requests
+    http-request deny deny_status 429 if too_many_requests
 
     # increase websocket idle timeout
     timeout client 30s


### PR DESCRIPTION
Essentially, we just force add the header before sending a 429 response.