### PR TITLE
Safer usage of `find`

### DIFF
--- a/bin/api.sh
+++ b/bin/api.sh
@@ -13,7 +13,7 @@ if [[ -n $SOLANA_INSTALL_UPDATE_MANIFEST ]]; then
 fi
 
 # Delete any zero-length snapshots that can cause validator startup to fail
-find ~/ledger/snapshot-* -size 0 -print -exec rm {} \; || true
+find ~/ledger/ -name 'snapshot-*' -size 0 -print -exec rm {} \; || true
 
 identity_keypair=~/api-identity.json
 identity_pubkey=$(solana-keygen pubkey $identity_keypair)

--- a/bin/validator.sh
+++ b/bin/validator.sh
@@ -8,7 +8,7 @@ source ~/service-env.sh
 ~/bin/check-hostname.sh
 
 # Delete any zero-length snapshots that can cause validator startup to fail
-find ~/ledger/snapshot-* -size 0 -print -exec rm {} \; || true
+find ~/ledger/ -name 'snapshot-*' -size 0 -print -exec rm {} \; || true
 
 #shellcheck source=/dev/null
 source ~/service-env-validator-*.sh

--- a/bin/warehouse.sh
+++ b/bin/warehouse.sh
@@ -25,7 +25,7 @@ source ~/service-env-warehouse-*.sh
 ~/bin/check-hostname.sh
 
 # Delete any zero-length snapshots that can cause validator startup to fail
-find ~/ledger/snapshot-* -size 0 -print -exec rm {} \; || true
+find ~/ledger/ -name 'snapshot-*' -size 0 -print -exec rm {} \; || true
 
 #shellcheck source=./configure-metrics.sh
 source "$here"/configure-metrics.sh


### PR DESCRIPTION
#### Problem

`find` is dumb and defaults to `/` if no paths are specified.  If our globs don't match any files, this is exactly what happens

#### Changes

Don't glob our path, specify it directly and glob on file name.