### PR TITLE
Remove legacy haproxy configuration

### DIFF
--- a/bin/machine-setup.sh
+++ b/bin/machine-setup.sh
@@ -235,6 +235,7 @@ frontend http
     default_backend jsonrpc
     use_backend pubsub if is_websocket
 
+# Only used when not behind other load balancers (reverse proxies)
 frontend https
     bind *:443 ssl crt /etc/ssl/private/haproxy.pem
 

--- a/bin/machine-setup.sh
+++ b/bin/machine-setup.sh
@@ -237,7 +237,6 @@ frontend http
 
 frontend https
     bind *:443 ssl crt /etc/ssl/private/haproxy.pem
-    bind *:8443 ssl crt /etc/ssl/private/haproxy.pem
 
     # capture/log requests
     option http-buffer-request
@@ -265,15 +264,6 @@ frontend https
 
     default_backend jsonrpc
     use_backend pubsub if is_websocket
-
-frontend wss
-    bind *:8901 ssl crt /etc/ssl/private/haproxy.pem
-    bind *:8444 ssl crt /etc/ssl/private/haproxy.pem
-
-    # increase websocket idle timeout
-    timeout client 30s
-
-    default_backend pubsub
 
 backend jsonrpc
     mode http


### PR DESCRIPTION
I lightly examined how these config is used across our live instances including api.mainnet-beta.solana.com, testnet.solana.com, break-api.solana.com as a due-diligence.

Also, I've familiarized myself a bit with haproxy. So, I'm sure removing this shouldn't cause any problem.

context: to unblock https://github.com/solana-labs/solana/pull/12245

fixes https://github.com/solana-labs/solana/pull/12250