### PR TITLE
Add account-index optional arg

### DIFF
--- a/bin/api.sh
+++ b/bin/api.sh
@@ -79,9 +79,9 @@ if [[ -n "$RPC_HEALTH_CHECK_SLOT_DISTANCE" ]]; then
   args+=(--health-check-slot-distance "$RPC_HEALTH_CHECK_SLOT_DISTANCE")
 fi
 
-if [[ -n "$ACCOUNT_INDEXES" ]]; then
-  args+=(--account-index "$ACCOUNT_INDEXES")
-fi
+for index in "${ACCOUNT_INDEXES[@]}"; do
+  args+=(--account-index "$index")
+done
 
 if [[ -r ~/api-vote-account.json ]]; then
   args+=(--vote-account ~/api-vote-account.json)

--- a/bin/api.sh
+++ b/bin/api.sh
@@ -79,6 +79,10 @@ if [[ -n "$RPC_HEALTH_CHECK_SLOT_DISTANCE" ]]; then
   args+=(--health-check-slot-distance "$RPC_HEALTH_CHECK_SLOT_DISTANCE")
 fi
 
+if [[ -n "$ACCOUNT_INDEXES" ]]; then
+  args+=(--account-index "$ACCOUNT_INDEXES")
+fi
+
 if [[ -r ~/api-vote-account.json ]]; then
   args+=(--vote-account ~/api-vote-account.json)
 else


### PR DESCRIPTION
As of v1.4.20 and v1.5.1, `solana-validator` supports optional account indexes (see https://github.com/solana-labs/solana/pull/14212). This pr gives us the option to enable one or more of these indexes on an api node by setting the `ACCOUNT_INDEXES` environment variable.